### PR TITLE
fixed #43

### DIFF
--- a/Amino.NET/Client.cs
+++ b/Amino.NET/Client.cs
@@ -1856,7 +1856,7 @@ namespace Amino
             var response = client.ExecuteGet(request);
             if ((int)response.StatusCode != 200) { throw new Exception(response.Content); }
             if (Debug) { Trace.WriteLine(response.Content); }
-            return System.Text.Json.JsonSerializer.Deserialize<FromCode>(JsonDocument.Parse(response.Content).RootElement.GetRawText());
+            return System.Text.Json.JsonSerializer.Deserialize<FromCode>(JsonDocument.Parse(response.Content).RootElement.GetProperty("linkInfoV2").GetRawText());
         }
 
         /// <summary>
@@ -1889,7 +1889,7 @@ namespace Amino
             var response = client.ExecutePost(request);
             if ((int)response.StatusCode != 200) { throw new Exception(response.Content); }
             if (Debug) { Trace.WriteLine(response.Content); }
-            return System.Text.Json.JsonSerializer.Deserialize<FromCode>(JsonDocument.Parse(response.Content).RootElement.GetRawText());
+            return System.Text.Json.JsonSerializer.Deserialize<FromCode>(JsonDocument.Parse(response.Content).RootElement.GetProperty("linkInfoV2").GetRawText());
         }
 
         /// <summary>

--- a/Amino.NET/Objects/LastChatMessageSummary.cs
+++ b/Amino.NET/Objects/LastChatMessageSummary.cs
@@ -6,7 +6,7 @@ namespace Amino.Objects
     {
         [JsonPropertyName("uid")] public string UserId { get; set; }
         [JsonPropertyName("isHidden")] public bool? IsHidden { get; set; }
-        [JsonPropertyName("mediaType")] public string MediaType { get; set; }
+        [JsonPropertyName("mediaType")] public int? MediaType { get; set; }
         [JsonPropertyName("content")] public string Content { get; set; }
         [JsonPropertyName("messageId")] public string MessageId { get; set; }
         [JsonPropertyName("createdTime")] public string CreatedTime { get; set; }

--- a/Amino.NET/Objects/WalletInfo.cs
+++ b/Amino.NET/Objects/WalletInfo.cs
@@ -10,7 +10,7 @@ namespace Amino.Objects
         [JsonPropertyName("adsEnabled")]public bool? AdsEnabled { get; set; }
         [JsonPropertyName("adsVideoStats")]public string AdsVideoStats { get; set; }
         [JsonPropertyName("adsFlag")]public string AdsFlag { get; set; }
-        [JsonPropertyName("totalCoins")]public int? TotalCoins { get; set; }
+        [JsonPropertyName("totalCoins")]public float? TotalCoins { get; set; }
         [JsonPropertyName("businessCoinsEnabled")]public bool? BusinessCoinsEnabled { get; set; }
         [JsonPropertyName("totalBusinessCoins")]public int? TotalBusinessCoins { get; set; }
         [JsonPropertyName("totalBusinessCoinsFloat")]public float? TotalBusinessCoinsFloat { get; set; }

--- a/Amino.NET/SubClient.cs
+++ b/Amino.NET/SubClient.cs
@@ -873,7 +873,7 @@ namespace Amino
             int optInAdsFlags = 2147483647;
             int tzf = helpers.TzFilter();
             data.Add("userActiveTimeChunkList", timeData);
-            data.Add("OptInAdsFlags", optInAdsFlags);
+            data.Add("optInAdsFlags", optInAdsFlags);
             data.Add("timestamp", (long)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalMilliseconds);
             data.Add("timezone", tzf);
 


### PR DESCRIPTION
[ # ] get_from_code & get_from_id now pass linkInfoV2 as root JSON key into the deserializer 
[ # ] LastMessageSummary.MediaType is now an int? instead of string 
[ # ] WalletInfo.TotalCoins is now a float? instead of int? because Amino API is weird (there literally is a totalCoinsFloat value????) 
[ # ] SubClient.send_activity_time now sends optInAdsFlags instead of OptInAdsFlags